### PR TITLE
Not include JSON ext to base URL when not needed

### DIFF
--- a/README
+++ b/README
@@ -63,7 +63,10 @@ EXAMPLE (for more example-code, refer to the Demo.java file)
 
 	// create the firebase
 	Firebase firebase = new Firebase( your_firebase_workspace_url );
-	
+
+	// exclude .json extension if it's not needed (ie, working with Firebase Authentication REST API)
+	Firebase firebase = new Firebase( your_firebase_workspace_url, false );
+
 	// PUT a map of some data into the firebase
 	Map<String, Object> dataMap = new LinkedHashMap<String, Object>();
 	dataMap.put( "PUT", "This was PUT into your workspace root" );
@@ -81,8 +84,8 @@ EXAMPLE (for more example-code, refer to the Demo.java file)
 	
 	// another alternative, you can PUT/POST your own JSON if you want
 	response = firebase.put( "PUT2", "{ 'key': 'Some value' }" );
-	
-	
+
+
 HELP
 
 	Please submit usage-questions to: brandon@thegreshams.net

--- a/src/net/thegreshams/firebase4j/demo/Demo.java
+++ b/src/net/thegreshams/firebase4j/demo/Demo.java
@@ -14,30 +14,42 @@ import org.codehaus.jackson.map.JsonMappingException;
 
 public class Demo {
 
+
 	public static void main(String[] args) throws FirebaseException, JsonParseException, JsonMappingException, IOException, JacksonUtilityException {
 
 		
 		// get the base-url (ie: 'http://gamma.firebase.com/username')
 		String firebase_baseUrl = null;
+
+		// get the api-key (ie: 'tR7u9Sqt39qQauLzXmRycXag18Z2')
+		String firebase_apiKey = null;
+
 		for( String s : args ) {
 
 			if( s == null || s.trim().isEmpty() ) continue;
-			if( s.trim().split( "=" )[0].equals( "baseUrl" ) ) {
-				firebase_baseUrl = s.trim().split( "=" )[1];
+			String[] split = s.trim().split( "=" );
+
+			if( split[0].equals("baseUrl") ) {
+				firebase_baseUrl = split[1];
 			}
+			else if( split[0].equals("apiKey") ) {
+				firebase_apiKey = split[1];
+			}
+
+
 		}
 		if( firebase_baseUrl == null || firebase_baseUrl.trim().isEmpty() ) {
 			throw new IllegalArgumentException( "Program-argument 'baseUrl' not found but required" );
 		}
 
-		
+
 		// create the firebase
 		Firebase firebase = new Firebase( firebase_baseUrl );
-		
-		
+
+
 		// "DELETE" (the fb4jDemo-root)
 		FirebaseResponse response = firebase.delete();
-	
+
 
 		// "PUT" (test-map into the fb4jDemo-root)
 		Map<String, Object> dataMap = new LinkedHashMap<String, Object>();
@@ -45,14 +57,14 @@ public class Demo {
 		response = firebase.put( dataMap );
 		System.out.println( "\n\nResult of PUT (for the test-PUT to fb4jDemo-root):\n" + response );
 		System.out.println("\n");
-		
-		
+
+
 		// "GET" (the fb4jDemo-root)
 		response = firebase.get();
 		System.out.println( "\n\nResult of GET:\n" + response );
 		System.out.println("\n");
-		
-		
+
+
 		// "PUT" (test-map into a sub-node off of the fb4jDemo-root)
 		dataMap = new LinkedHashMap<String, Object>();
 		dataMap.put( "Key_1", "This is the first value" );
@@ -63,20 +75,20 @@ public class Demo {
 		response = firebase.put( "test-PUT", dataMap );
 		System.out.println( "\n\nResult of PUT (for the test-PUT):\n" + response );
 		System.out.println("\n");
-		
-		
+
+
 		// "GET" (the test-PUT)
 		response = firebase.get( "test-PUT" );
 		System.out.println( "\n\nResult of GET (for the test-PUT):\n" + response );
 		System.out.println("\n");
-		
-		
+
+
 		// "POST" (test-map into a sub-node off of the fb4jDemo-root)
 		response = firebase.post( "test-POST", dataMap );
 		System.out.println( "\n\nResult of POST (for the test-POST):\n" + response );
 		System.out.println("\n");
-		
-		
+
+
 		// "DELETE" (it's own test-node)
 		dataMap = new LinkedHashMap<String, Object>();
 		dataMap.put( "DELETE", "This should not appear; should have been DELETED" );
@@ -86,7 +98,27 @@ public class Demo {
 		System.out.println( "\n\nResult of DELETE (for the test-DELETE):\n" + response );
 		response = firebase.get( "test-DELETE" );
 		System.out.println( "\n\nResult of GET (for the test-DELETE):\n" + response );
-		
+
+		// Sign Up user for Firebase's Auth Service demo (https://firebase.google.com/docs/reference/rest/auth/)
+		if(firebase_apiKey != null) {
+
+			firebase = new Firebase("https://www.googleapis.com/identitytoolkit/v3/relyingparty", false);
+			firebase.addQuery("key", firebase_apiKey);
+
+			dataMap.clear();
+			dataMap.put("email", "elonmusk@tesla.com");
+			dataMap.put("password", "TeslaRocks");
+			dataMap.put("returnSecureToken", true);
+
+			response = firebase.post("signupNewUser", dataMap);
+			System.out.println("\n\nResult of Signing Up:\n" + response);
+			System.out.println("\n");
+
+		} else {
+			System.out.println("\n\nResult of Signing Up:\n failed, because no API Key was provided.");
+			System.out.println("\n");
+		}
+
 	}
 	
 }

--- a/src/net/thegreshams/firebase4j/service/Firebase.java
+++ b/src/net/thegreshams/firebase4j/service/Firebase.java
@@ -53,8 +53,8 @@ public class Firebase {
 	private final String baseUrl;
 	private String secureToken = null;
 	private List<NameValuePair> query;
-	
-	
+	private Boolean useJsonExt = true;
+
 	public Firebase( String baseUrl ) throws FirebaseException {
 
 		if( baseUrl == null || baseUrl.trim().isEmpty() ) {
@@ -66,7 +66,18 @@ public class Firebase {
 		query = new ArrayList<NameValuePair>();
 		LOGGER.info( "intialized with base-url: " + this.baseUrl );
 	}
-	
+
+	/**
+	 * Overloaded constructor for cases where you need to prevent adding the json extension to the url.
+	 * @param baseUrl
+	 * @param useJsonExtension include the json extension to the URL?
+	 * @throws FirebaseException
+	 */
+	public Firebase( String baseUrl, Boolean useJsonExtension ) throws FirebaseException {
+		this(baseUrl);
+		useJsonExt = useJsonExtension;
+	}
+
 	public Firebase(String baseUrl, String secureToken) throws FirebaseException {
 		if( baseUrl == null || baseUrl.trim().isEmpty() ) {
 			String msg = "baseUrl cannot be null or empty; was: '" + baseUrl + "'";
@@ -455,7 +466,10 @@ public class Firebase {
 		if( !path.isEmpty() && !path.startsWith( "/" ) ) {
 			path = "/" + path;
 		}
-		String url = this.baseUrl + path + Firebase.FIREBASE_API_JSON_EXTENSION;
+
+		String url = this.baseUrl + path;
+
+		if(useJsonExt) url += Firebase.FIREBASE_API_JSON_EXTENSION;
 		
 		if(query != null) {
 			url += "?";


### PR DESCRIPTION
Previous versions always included .json extension
to the base URL in the Firebase class when building a full URL.

It is indeed needed when working with the Firebase's Database service,
but on the other hand, brings issues when working with
the Authentication service API
(https://firebase.google.com/docs/reference/rest/auth/). The URLs there
don't need any extensions.

The merge with attached commits provides the user with an opportunity to specify in
the constructor of Firebase class not to add that extension to the URL.

Demo class is updated accordingly; an example of signing up a user
is provided.